### PR TITLE
修改了网关和子设备对于下发命令时，Sprintf topic 的格式

### DIFF
--- a/internal/service/command_data.go
+++ b/internal/service/command_data.go
@@ -151,7 +151,7 @@ func (*CommandData) CommandPutMessage(ctx context.Context, userID string, param 
 				"sql_error": err.Error(),
 			})
 		}
-		topic = fmt.Sprintf("%s%s/%s", config.MqttConfig.Commands.GatewayPublishTopic, gatewayInfo.DeviceNumber, messageID)
+		topic = fmt.Sprintf(config.MqttConfig.Commands.GatewayPublishTopic, gatewayInfo.DeviceNumber, messageID)
 	}
 
 	// 序列化payload


### PR DESCRIPTION
![8271cf0e748584e6ed9841dde5d42d4e](https://github.com/user-attachments/assets/1ff0f563-8ffe-4edf-9f9a-a1bed9ee4c26)
![900dccb6589f5f745e95c26df5c42d8e](https://github.com/user-attachments/assets/38b50b60-2076-4eea-b45b-76047e51102a)
![d18a93d9cd515d7d2ff00fdfe85c855b](https://github.com/user-attachments/assets/c91874b9-c579-4227-8c81-2eb3a4d3ef7f)
网关和子设备对于下发命令，Sprintf topic 和conf.yal 定义不匹配，导致客户端收不到推送